### PR TITLE
Fixed bots not looking for ! at the start of commands

### DIFF
--- a/mrsbfh-macros/src/lib.rs
+++ b/mrsbfh-macros/src/lib.rs
@@ -341,7 +341,7 @@ pub fn commands(_: TokenStream, input: TokenStream) -> TokenStream {
                                 let command_raw = split.next().expect("This is not a command").to_lowercase();
                                 let command = command_matcher_magic.captures(command_raw.as_str())
                                                                    .map_or(String::new(), |caps| {
-                                                                        caps.get(0)
+                                                                        caps.get(1)
                                                                             .map_or(String::new(),
                                                                                     |m| String::from(m.as_str()))
                                                                    });


### PR DESCRIPTION
This PR adds support for bots misinterpreting the messages "!cmd" and "cmd" as equivalent. It would cause unwanted spam and processing cycles. I have added a regex that looks for the "!" at the start of the command and then strips it out or returns an empty string if it does not find a "!" at the start of the message.