### PR TITLE
Fix unneeded rust dependancies for mrsbfh

### DIFF
--- a/example-bot/Cargo.toml
+++ b/example-bot/Cargo.toml
@@ -12,6 +12,13 @@ repository = "https://github.com/MTRNord/mrsbfh"
 [dependencies.matrix-sdk]
 version = "0.4.1"
 
+# To create a bot that uses the Rust implementation of TLS use the default features minus native-tls
+# Ex:
+# [dependencies.matrix-sdk]
+# version = "0.4.1"
+# default_features = false
+# features = ["encryption", "sled_cryptostore", "sled_state_store", "require_auth_for_profile_requests", "rustls-tls"]
+
 [dependencies]
 mrsbfh = {version = "0.2.0", path = "../mrsbfh"}
 serde = "1.0"

--- a/mrsbfh/Cargo.toml
+++ b/mrsbfh/Cargo.toml
@@ -13,7 +13,6 @@ readme = "../README.md"
 [dependencies.matrix-sdk]
 version = "0.4.1"
 default_features = false
-features = ["encryption", "sled_cryptostore", "sled_state_store", "require_auth_for_profile_requests"]
 
 [dependencies]
 url = "2.2.1"
@@ -37,7 +36,5 @@ async-trait = "0.1"
 lazy_static = "1"
 
 [features]
-default = ["macros", "native-tls"]
+default = ["macros"]
 macros = ["mrsbfh-macros"]
-rustls = ["matrix-sdk/rustls-tls"]
-native-tls = ["matrix-sdk/native-tls"]


### PR DESCRIPTION
Fixes #8 

It still requires the end user to pull in the matrix-sdk but doesn't force features that they may not want. If the framework starts reducing the amount of setup ( having the store and session paths be created via a function or macro in the framework) then for those functions to be enabled start requiring features of the matrix-sdk that would be needed