### PR TITLE
Fixes tripping hazard for the command that is generated after the proc macros

### DIFF
--- a/example-bot/src/commands/mod.rs
+++ b/example-bot/src/commands/mod.rs
@@ -6,5 +6,5 @@ pub mod hello_world;
 
 #[command_generate(bot_name = "Example", description = "This bot prints hello!")]
 enum Commands {
-    HelloWorld,
+    Hello_World,
 }


### PR DESCRIPTION
Fixes: #9

Small change to get the example in line with what the help text for the command says, the command mangling macro may need to be updated so that the end command generated still follows Rust's naming convention 